### PR TITLE
Fix: comment from echo to gin

### DIFF
--- a/oapi_validate.go
+++ b/oapi_validate.go
@@ -171,7 +171,7 @@ func ValidateRequestFromContext(c *gin.Context, router routers.Router, options *
 	return nil
 }
 
-// GetGinContext gets the echo context from within requests. It returns
+// GetGinContext gets the gin context from within requests. It returns
 // nil if not found or wrong type.
 func GetGinContext(c context.Context) *gin.Context {
 	iface := c.Value(GinContextKey)

--- a/oapi_validate_test.go
+++ b/oapi_validate_test.go
@@ -87,7 +87,7 @@ func TestOapiRequestValidator(t *testing.T) {
 	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
 	require.NoError(t, err, "Error initializing swagger")
 
-	// Create a new echo router
+	// Create a new gin router
 	g := gin.New()
 
 	// Set up an authenticator to check authenticated function. It will allow


### PR DESCRIPTION
This middleware is for 'gin', but several comments are remained 'echo'.